### PR TITLE
Specify autogen model via dotenv #14

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,2 +1,5 @@
-OPENAI_API_KEY=1234
+AUTOGEN_MODEL_NAME=PUT YOUR MODEL NAME HERE, for example: gpt-4-turbo-preview or llama3-70b-8192
+AUTOGEN_MODEL_API_KEY=PUT YOUR MODEL API KEY HERE
+AUTOGEN_MODEL_BASE_URL=IF YOU ARE USING OpenAI, remove this line, otherwise add the base URL, for example: https://api.groq.com/openai/v1
+
 BROWSER_STORAGE_DIR=/Users/macuser/Library/Application Support/Google/Chrome/Profile 5

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ While Agent-E is growing, it is already equipped to handle a versatile range of 
 - To install extras/dev dependancies: `uv pip install -r pyproject.toml --extra dev`
 - If you do not have Google Chrome locally (and don't want to install it), install playwright drivers: `playwright install`
 - .env file in project root is needed with the following (sample `.env-example` is included for convience):
-    - `OPENAI_API_KEY=put_you-openai_key_here`
+    - Follow the directions in the sample file
+    - You will need to set `AUTOGEN_MODEL_NAME` (for example `gpt-4-turbo-preview`) and `AUTOGEN_MODEL_API_KEY`
+    - If you are using a model other than OpenAI, you need to set `AUTOGEN_MODEL_BASE_URL` for example `https://api.groq.com/openai/v1`
     - If you want to use local chrome browser over playwright browser, go to chrome://version/ in chrome, find the path to your profile and set `BROWSER_STORAGE_DIR` to the path value
 
 ### pip issues


### PR DESCRIPTION
Move config of which model autogen uses to `.env` file rather than hardcoded