### PR TITLE
Adding mutation observer on element additions only

### DIFF
--- a/ae/core/playwright_manager.py
+++ b/ae/core/playwright_manager.py
@@ -232,8 +232,13 @@ class PlaywrightManager:
 
 
     async def set_navigation_handler(self):
+        from ae.utils.dom_mutation_observer import handle_navigation_for_mutation_observer
+        from ae.utils.dom_mutation_observer import dom_mutation_change_detected
+
         page:Page = await PlaywrightManager.get_current_page(self)
         page.on("domcontentloaded", self.ui_manager.handle_navigation) # type: ignore
+        page.on("domcontentloaded", handle_navigation_for_mutation_observer) # type: ignore
+        await page.expose_function("dom_mutation_change_detected", dom_mutation_change_detected) # type: ignore
 
 
     async def set_overlay_state_handler(self):

--- a/ae/core/skills/click_using_selector.py
+++ b/ae/core/skills/click_using_selector.py
@@ -8,7 +8,8 @@ from playwright.async_api import Page
 from ae.core.playwright_manager import PlaywrightManager
 from ae.utils.dom_helper import get_element_outer_html
 from ae.utils.logger import logger
-
+from ae.utils.dom_mutation_observer import subscribe 
+from ae.utils.dom_mutation_observer import unsubscribe 
 
 async def click(selector: Annotated[str, "The properly formed query selector string to identify the element for the click action. When \"mmid\" attribute is present, use it for the query selector."],
                 wait_before_execution: Annotated[float, "Optional wait time in seconds before executing the click event logic.", float] = 0.0) -> Annotated[str, "A message indicating success or failure of the click."]:
@@ -33,6 +34,22 @@ async def click(selector: Annotated[str, "The properly formed query selector str
         raise ValueError('No active page found. OpenURL command opens a new page.')
 
     await browser_manager.highlight_element(selector, True)
+    
+    dom_changes_detected=None
+    def detect_dom_changes(changes:str): # type: ignore
+        nonlocal dom_changes_detected
+        dom_changes_detected = changes # type: ignore
+
+    subscribe(detect_dom_changes)
+    result = await do_click(page, selector, wait_before_execution)
+    await asyncio.sleep(0.1) # sleep for 100ms to allow the mutation observer to detect changes
+    unsubscribe(detect_dom_changes)
+    await browser_manager.notify_user(result["summary_message"])
+    if dom_changes_detected:
+        return f"{result['detailed_message']}.\n As a consequence of this action, new elements have appeared in view: {dom_changes_detected}. This could be a modal dialog. Get all_fields to interact with the elements."
+    return result["detailed_message"]
+
+
     result = await do_click(page, selector, wait_before_execution)
     await browser_manager.notify_user(result["summary_message"])
     return result["detailed_message"]

--- a/ae/core/skills/enter_text_and_click.py
+++ b/ae/core/skills/enter_text_and_click.py
@@ -46,12 +46,6 @@ async def enter_text_and_click(
 
     await browser_manager.highlight_element(text_selector, True)
 
-    dom_changes_detected=None
-    def detect_dom_changes(changes:str): # type: ignore
-        nonlocal dom_changes_detected
-        dom_changes_detected = changes # type: ignore
-
-    subscribe(detect_dom_changes)
     text_entry_result = await do_entertext(page, text_selector, text_to_enter, use_keyboard_fill=True)
 
     await browser_manager.notify_user(text_entry_result["summary_message"])
@@ -77,8 +71,4 @@ async def enter_text_and_click(
         await browser_manager.notify_user(do_click_result["summary_message"])
     
     await asyncio.sleep(0.1) # sleep for 100ms to allow the mutation observer to detect changes
-    unsubscribe(detect_dom_changes)
-
-    if dom_changes_detected:
-        return f"{result['detailed_message']}.\n As a consequence of this action, new elements have appeared in view: {dom_changes_detected}. This could be a modal dialog. Get all_fields to interact with the elements."
     return result["detailed_message"]

--- a/ae/core/skills/enter_text_and_click.py
+++ b/ae/core/skills/enter_text_and_click.py
@@ -5,8 +5,6 @@ from ae.core.skills.click_using_selector import do_click
 from ae.core.skills.enter_text_using_selector import do_entertext
 from ae.core.skills.press_key_combination import do_press_key_combination
 from ae.utils.logger import logger
-from ae.utils.dom_mutation_observer import subscribe 
-from ae.utils.dom_mutation_observer import unsubscribe 
 import asyncio 
 
 async def enter_text_and_click(

--- a/ae/core/skills/enter_text_and_click.py
+++ b/ae/core/skills/enter_text_and_click.py
@@ -5,7 +5,9 @@ from ae.core.skills.click_using_selector import do_click
 from ae.core.skills.enter_text_using_selector import do_entertext
 from ae.core.skills.press_key_combination import do_press_key_combination
 from ae.utils.logger import logger
-
+from ae.utils.dom_mutation_observer import subscribe 
+from ae.utils.dom_mutation_observer import unsubscribe 
+import asyncio 
 
 async def enter_text_and_click(
     text_selector: Annotated[str, "The properly formatted DOM selector query, for example [mmid='1234'], where the text will be entered. Use mmid attribute."],
@@ -43,7 +45,15 @@ async def enter_text_and_click(
         raise ValueError('No active page found. OpenURL command opens a new page.')
 
     await browser_manager.highlight_element(text_selector, True)
+
+    dom_changes_detected=None
+    def detect_dom_changes(changes:str): # type: ignore
+        nonlocal dom_changes_detected
+        dom_changes_detected = changes # type: ignore
+
+    subscribe(detect_dom_changes)
     text_entry_result = await do_entertext(page, text_selector, text_to_enter, use_keyboard_fill=True)
+
     await browser_manager.notify_user(text_entry_result["summary_message"])
     if not text_entry_result["summary_message"].startswith("Success"):
         return(f"Failed to enter text '{text_to_enter}' into element with selector '{text_selector}'. Check that the selctor is valid.")
@@ -61,8 +71,14 @@ async def enter_text_and_click(
             await browser_manager.notify_user("Failed to press the Enter key on element \"{click_selector}\".")
     else:
         await browser_manager.highlight_element(click_selector, True)
+
         do_click_result = await do_click(page, click_selector, wait_before_click_execution)
         result["detailed_message"] += f' {do_click_result["detailed_message"]}'
         await browser_manager.notify_user(do_click_result["summary_message"])
+    
+    await asyncio.sleep(0.1) # sleep for 100ms to allow the mutation observer to detect changes
+    unsubscribe(detect_dom_changes)
 
+    if dom_changes_detected:
+        return f"{result['detailed_message']}.\n As a consequence of this action, new elements have appeared in view: {dom_changes_detected}. This could be a modal dialog. Get all_fields to interact with the elements."
     return result["detailed_message"]

--- a/ae/core/skills/enter_text_using_selector.py
+++ b/ae/core/skills/enter_text_using_selector.py
@@ -170,8 +170,7 @@ async def do_entertext(page: Page, selector: str, text_to_enter: str, use_keyboa
             await custom_fill_element(page, selector, text_to_enter)
         logger.info(f"Success. Text \"{text_to_enter}\" set successfully in the element with selector {selector}")
         await elem.focus()
-        await page.keyboard.type(" ") # some html pages can have placeholders that only disappear upon keyboard input
-        await press_key_combination("Backspace") # remove the space
+        await page.keyboard.type("") # some html pages can have placeholders that only disappear upon keyboard input
         await asyncio.sleep(1)
         success_msg = f"Success. Text \"{text_to_enter}\" set successfully in the element with selector {selector}"
         

--- a/ae/core/skills/enter_text_using_selector.py
+++ b/ae/core/skills/enter_text_using_selector.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from typing import List  # noqa: UP035
 
 from playwright.async_api import Page
-
+from ae.core.skills.press_key_combination import press_key_combination
 from ae.core.playwright_manager import PlaywrightManager
 from ae.utils.dom_helper import get_element_outer_html
 from ae.utils.logger import logger
@@ -161,6 +161,9 @@ async def do_entertext(page: Page, selector: str, text_to_enter: str, use_keyboa
 
         if use_keyboard_fill:
             await elem.focus()
+            await press_key_combination("Control+A")
+            await asyncio.sleep(0.2)
+            await press_key_combination("Backspace")
             logger.debug(f"Focused element with selector {selector} to enter text")
             await page.keyboard.type(text_to_enter, delay=2)
         else:
@@ -168,6 +171,7 @@ async def do_entertext(page: Page, selector: str, text_to_enter: str, use_keyboa
         logger.info(f"Success. Text \"{text_to_enter}\" set successfully in the element with selector {selector}")
         await elem.focus()
         await page.keyboard.type(" ") # some html pages can have placeholders that only disappear upon keyboard input
+        await press_key_combination("Backspace") # remove the space
         await asyncio.sleep(1)
         success_msg = f"Success. Text \"{text_to_enter}\" set successfully in the element with selector {selector}"
         

--- a/ae/utils/dom_mutation_observer.py
+++ b/ae/utils/dom_mutation_observer.py
@@ -1,0 +1,71 @@
+
+import json
+from playwright.async_api import Page
+from typing import List, Callable
+from playwright.async_api import Page
+import asyncio
+
+# Create an event loop
+loop = asyncio.get_event_loop()
+
+DOM_change_callback: List[Callable[[str], None]] = []
+
+def subscribe(callback: Callable[[str], None]) -> None:
+    DOM_change_callback.append(callback) 
+
+def unsubscribe(callback: Callable[[str], None]) -> None:
+    DOM_change_callback.remove(callback)
+
+
+async def add_mutation_observer(page:Page):
+    """ 
+    Adds a mutation observer to the page to detect changes in the DOM. 
+    When changes are detected, the observer calls the dom_mutation_change_detected function in the browser context.
+    This changes can be detected by subscribing to the dom_mutation_change_detected function by individual skills.
+
+    Current implementation only detects when a new node is added to the DOM. 
+    However, in many cases, the change could be a change in the style or class of an existing node (e.g. toggle visibility of a hidden node).
+    """
+
+    await page.evaluate("""                         
+    console.log('Adding a mutation observer for DOM changes');
+    new MutationObserver((mutationsList, observer) => { 
+        let changes_detected = [];
+        for(let mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                let allAddedNodes=mutation.addedNodes;
+                for(let node of allAddedNodes) {
+                    if(node.tagName && !['SCRIPT', 'NOSCRIPT', 'STYLE'].includes(node.tagName) && !node.closest('#agentDriveAutoOverlay')) {
+                        let visibility=node.offsetWidth > 0 && node.offsetHeight > 0;  
+                        let content = node.innerText.trim();
+                        if(visibility && node.innerText.trim() && window.getComputedStyle(node).display !== 'none'){
+                            if(content && !changes_detected.some(change => change.content.includes(content))) {
+                                changes_detected.push({tag: node.tagName, content: content});
+                            }
+                        }                    
+                    }
+                }
+            }
+            } 
+        if(changes_detected.length > 0) {
+            window.dom_mutation_change_detected(JSON.stringify(changes_detected));
+        } 
+    }).observe(document, {subtree: true, childList: true}); 
+    """)
+
+
+async def handle_navigation_for_mutation_observer(page:Page):
+    print('Handling navigation for mutation observer')
+    await add_mutation_observer(page)
+
+async def dom_mutation_change_detected(changes_detected: str):
+    changes_detected = json.loads(changes_detected.replace('\t', '').replace('\n', ''))
+    if len(changes_detected) > 0:
+        # Emit the event to all subscribed callbacks
+        for callback in DOM_change_callback:
+            # If the callback is a coroutine function
+            if asyncio.iscoroutinefunction(callback):
+                await callback(changes_detected)
+            # If the callback is a regular function
+            else:
+                callback(changes_detected)


### PR DESCRIPTION
Works very well within the limitations of the implementation (only triggers when new DOM elements are added).
However, not sure how it should fit into compound skills since new elements maybe added and then removed as a consequence of the multiple actions. 
E.g. imagine entering Source and Destination in a flight booking site. Source will trigger a drop down with potential matches, and it will disappear when destination is entered. So any Source related element additions are not valid anymore. 

Other option could be we keep track of added and removed nodes and somehow  give a net change, which gets complicated logic wise.  