### PR TITLE
OpenAI call changes towards more deterministic responses

### DIFF
--- a/ae/core/agents/browser_nav_agent.py
+++ b/ae/core/agents/browser_nav_agent.py
@@ -43,7 +43,9 @@ class BrowserNavAgent:
             llm_config={
                 "config_list": config_list,
                 "cache_seed": None,
-                "temperature": 0.0
+                "temperature": 0.0,
+                "top_p": 0.001,
+                "seed":12345
             },
         )
         self.__register_skills()

--- a/ae/core/agents/high_level_planner_agent.py
+++ b/ae/core/agents/high_level_planner_agent.py
@@ -34,7 +34,9 @@ class PlannerAgent:
             llm_config={
                 "config_list": config_list,
                 "cache_seed": None,
-                "temperature": 0.0
+                "temperature": 0.0,
+                "top_p": 0.001,
+                "seed":12345
             },
         )
 


### PR DESCRIPTION
Even with a temperature 0, the response can be very non-deterministic, sometimes to the extent that plans returned by the planner are different. 

Setting a low top_p and a "seed" are additional steps that can be taken to move towards deterministic responses. https://cookbook.openai.com/examples/reproducible_outputs_with_the_seed_parameter