### PR TITLE
API can set max chat rounds per agent

### DIFF
--- a/ae/core/autogen_wrapper.py
+++ b/ae/core/autogen_wrapper.py
@@ -123,6 +123,8 @@ class AutogenWrapper:
             self.__save_chat_log(list(messages_str_keys.values())[0]) # type: ignore
             last_message=recipient.last_message(sender)["content"] # type: ignore
             if not last_message or last_message.strip() == "": # type: ignore
+                # print(f">>> Last message from browser nav was empty. Max turns: {self.browser_number_of_rounds*2}, number of messages: {len(list(sender.chat_messages.items())[0][1])}")
+                # print(">>> Sender messages:", json.dumps( list(sender.chat_messages.items())[0][1], indent=2))
                 return "I received an empty message. This is not an error and is recoverable. Try to reformulate the task..."
             elif "##TERMINATE TASK##" in last_message:
                 last_message=last_message.replace("##TERMINATE TASK##", "") # type: ignore

--- a/ae/core/system_orchestrator.py
+++ b/ae/core/system_orchestrator.py
@@ -29,15 +29,20 @@ class SystemOrchestrator:
         shutdown_event (asyncio.Event): Event to wait for an exit command to be processed.
     """
 
-    def __init__(self, agent_scenario:str="user,planner_agent,browser_nav_agent,browser_nav_executor", input_mode:str="GUI_ONLY"):
+    def __init__(self, agent_scenario:str="user,planner_agent,browser_nav_agent,browser_nav_executor", input_mode:str="GUI_ONLY",
+                 planner_max_chat_round: int = 50, browser_nav_max_chat_round: int = 10):
         """
         Initializes the system orchestrator with the specified agent scenario and input mode.
 
         Args:
             agent_scenario (str, optional): The agent scenario to use for command processing. Defaults to "user_proxy,browser_nav_agent".
             input_mode (str, optional): The input mode of the system. Defaults to "GUI_ONLY".
+            planner_max_chat_rounds (int, optional): The maximum number of chat rounds for the planner. Defaults to 50.
+            browser_nav_max_chat_round (int, optional): The maximum number of chat rounds for the browser navigation agent. Defaults to 10.
         """
         load_dotenv()
+        self.planner_number_of_rounds = planner_max_chat_round
+        self.browser_number_of_rounds = browser_nav_max_chat_round
 
         self.agent_scenario = agent_scenario
         self.input_mode = input_mode
@@ -90,7 +95,8 @@ class SystemOrchestrator:
         self.browser_nav_agent_config = llm_config.get_browser_nav_agent_config()
 
         self.autogen_wrapper = await AutogenWrapper.create(self.planner_agent_config, self.browser_nav_agent_config, agents_needed=self.agent_names,
-                                                           save_chat_logs_to_files=self.save_chat_logs_to_files)
+                                                           save_chat_logs_to_files=self.save_chat_logs_to_files,
+                                                           planner_max_chat_round=self.planner_number_of_rounds, browser_nav_max_chat_round=self.browser_number_of_rounds)
 
         self.browser_manager = browserManager.PlaywrightManager(gui_input_mode=self.input_mode == "GUI_ONLY")
         await self.browser_manager.async_initialize()

--- a/ae/server/api_routes.py
+++ b/ae/server/api_routes.py
@@ -40,6 +40,8 @@ logger = logging.getLogger("uvicorn")
 class CommandQueryModel(BaseModel):
     command: str = Field(..., description="The command related to web navigation to execute.")  # Required field with description
     llm_config: dict[str,Any] | None = Field(None, description="The LLM configuration string to use for the agents.")
+    planner_max_chat_round: int = Field(50, description="The maximum number of chat rounds for the planner.")
+    browser_nav_max_chat_round: int = Field(10, description="The maximum number of chat rounds for the browser navigation agent.")
     clientid: str | None = Field(None, description="Client identifier, optional")
     request_originator: str | None = Field(None, description="Optional id of the request originator")
 
@@ -74,10 +76,13 @@ async def execute_task(request: Request, query_model: CommandQueryModel):
     notification_queue = Queue()  # type: ignore
     transaction_id = str(uuid.uuid4()) if query_model.clientid is None else query_model.clientid
     register_notification_listener(notification_queue)
-    return StreamingResponse(run_task(request, transaction_id, query_model.command, browser_manager, notification_queue, query_model.request_originator, query_model.llm_config), media_type="text/event-stream")
+    return StreamingResponse(run_task(request, transaction_id, query_model.command, browser_manager, notification_queue, query_model.request_originator,query_model.llm_config,
+                                      planner_max_chat_round=query_model.planner_max_chat_round,
+                                      browser_nav_max_chat_round=query_model.browser_nav_max_chat_round), media_type="text/event-stream")
 
 
-def run_task(request: Request, transaction_id: str, command: str, playwright_manager: browserManager.PlaywrightManager, notification_queue: Queue, request_originator: str|None = None, llm_config: dict[str,Any]|None = None):  # type: ignore
+def run_task(request: Request, transaction_id: str, command: str, playwright_manager: browserManager.PlaywrightManager, notification_queue: Queue, request_originator: str|None = None, llm_config: dict[str,Any]|None = None,   # type: ignore
+             planner_max_chat_round: int = 50, browser_nav_max_chat_round: int = 10):
     """
     Run the task to process the command and generate events.
 
@@ -88,13 +93,16 @@ def run_task(request: Request, transaction_id: str, command: str, playwright_man
         playwright_manager (PlaywrightManager): The manager handling browser interactions and notifications.
         notification_queue (Queue): The queue to hold notifications for this request.
         request_originator (str|None): The originator of the request.
+        llm_config (dict[str,Any]|None): The LLM configuration to use for the agents.
+        planner_max_chat_rounds (int, optional): The maximum number of chat rounds for the planner. Defaults to 50.
+        browser_nav_max_chat_round (int, optional): The maximum number of chat rounds for the browser navigation agent. Defaults to 10.
 
     Yields:
         str: JSON-encoded string representing a notification.
     """
 
     async def event_generator():
-        task = asyncio.create_task(process_command(command, playwright_manager, llm_config))
+        task = asyncio.create_task(process_command(command, playwright_manager, planner_max_chat_round, browser_nav_max_chat_round, llm_config))
         task_detail = f"transaction_id={transaction_id}, request_originator={request_originator}, command={command}"
 
         try:
@@ -124,7 +132,7 @@ def run_task(request: Request, transaction_id: str, command: str, playwright_man
 
 
 
-async def process_command(command: str, playwright_manager: browserManager.PlaywrightManager, llm_config:dict[str,Any]|None = None):
+async def process_command(command: str, playwright_manager: browserManager.PlaywrightManager, planner_max_chat_round: int, browser_nav_max_chat_round: int, llm_config:dict[str,Any]|None = None):
     """
     Process the command and send notifications.
 
@@ -148,7 +156,8 @@ async def process_command(command: str, playwright_manager: browserManager.Playw
     planner_agent_config = normalized_llm_config.get_planner_agent_config()
     browser_nav_agent_config = normalized_llm_config.get_browser_nav_agent_config()
 
-    ag = await AutogenWrapper.create(planner_agent_config, browser_nav_agent_config)
+    ag = await AutogenWrapper.create(planner_agent_config, browser_nav_agent_config, planner_max_chat_round=planner_max_chat_round,
+                                     browser_nav_max_chat_round=browser_nav_max_chat_round)
     command_exec_result = await ag.process_command(command, current_url)  # type: ignore
 
     # Notify about the completion of the command

--- a/ae/utils/formatting_helper.py
+++ b/ae/utils/formatting_helper.py
@@ -1,4 +1,9 @@
 
+import json
+import re
+from typing import Any
+
+
 def str_to_bool(s: str | bool) -> bool:
     """
     Convert a string representation of truth to True or False.
@@ -13,3 +18,39 @@ def str_to_bool(s: str | bool) -> bool:
         return s
     return s.lower() in ['true', '1', 't', 'y', 'yes']
 
+def str_to_json(s: str) -> dict[str, Any] | None:
+    """
+    Convert a string representation of a JSON object to a dictionary.
+
+    Parameters:
+    s (str): The string to convert.
+
+    Returns:
+    dict[str, Any] | None: The dictionary representation of the JSON object. If the parsing fails, returns None.
+    """
+    s_fixed = re.sub(r'(?<!\\)\n', '\\n', s) #escape newline characters as long as they are not already escaped
+
+# Now you can safely load it using json.loads
+    try:
+        obj = json.loads(s_fixed)
+        return obj
+    except json.JSONDecodeError as e:
+        return None
+
+def is_terminating_message(message: str) -> bool:
+    """
+    Check if a message is a terminating message.
+
+    Parameters:
+    message (str): The message to check.
+
+    Returns:
+    bool: True if the message is a terminating message, False otherwise.
+    """
+    message_as_json = str_to_json(message)
+    if message_as_json is None:
+        if message.find('"terminate": "yes"') != -1:
+            return True
+        return False
+    else:
+        return message_as_json.get("terminate") == "yes"

--- a/ae/utils/ui_messagetype.py
+++ b/ae/utils/ui_messagetype.py
@@ -11,3 +11,4 @@ class MessageType(Enum):
     FINAL = "final"
     DONE = "transaction_done"
     ERROR = "error"
+    MAX_TURNS_REACHED = "max_turns_reached"


### PR DESCRIPTION
A good way to test this:
```
curl --location 'http://127.0.0.1:8000/execute_task' \
--header 'Content-Type: application/json' \
--data '{
    "command": "go to allrecipes.com and find chicken pasta recipe",
    "planner_max_chat_round": 3,
    "browser_nav_max_chat_round": 3
}'
```